### PR TITLE
`isless` for bitmasks

### DIFF
--- a/src/Vulkan.jl
+++ b/src/Vulkan.jl
@@ -4,7 +4,7 @@ using DocStringExtensions
 using VulkanCore
 using VulkanCore.vk
 using Base: RefArray
-import Base: convert, cconvert, unsafe_convert, &, |, xor
+import Base: convert, cconvert, unsafe_convert, &, |, xor, isless
 using MLStyle
 
 using Reexport

--- a/src/prewrap/bitmasks.jl
+++ b/src/prewrap/bitmasks.jl
@@ -38,10 +38,10 @@ isless(a::T, b::T) where {T <: BitMask} = T(isless(a.val, b.val))
 xor(a::T, b::Integer) where {T <: BitMask} = T(xor(a.val, b))
 isless(a::T, b::Integer) where {T <: BitMask} = T(isless(a.val, b))
 
-(&)(a::Integer, b::T) where {T <: BitMask} = b & a
-(|)(a::Integer, b::T) where {T <: BitMask} = b | a
-xor(a::Integer, b::T) where {T <: BitMask} = xor(b, a)
-isless(a::Integer, b::T) where {T <: BitMask} = isless(b, a)
+(&)(a::Integer, b::T) where {T <: BitMask} = b.val & a
+(|)(a::Integer, b::T) where {T <: BitMask} = b.val | a
+xor(a::Integer, b::T) where {T <: BitMask} = xor(b.val, a)
+isless(a::Integer, b::T) where {T <: BitMask} = isless(b.val, a)
 
 (::Type{T})(bm::BitMask) where {T <: Integer} = T(bm.val)
 

--- a/src/prewrap/bitmasks.jl
+++ b/src/prewrap/bitmasks.jl
@@ -26,18 +26,22 @@ end
 (&)(a::BitMask, b::BitMask) = error("Bitwise operation not allowed between incompatible bitmasks '$(typeof(a))', '$(typeof(b))'")
 (|)(a::BitMask, b::BitMask) = error("Bitwise operation not allowed between incompatible bitmasks '$(typeof(a))', '$(typeof(b))'")
 xor(a::BitMask, b::BitMask) = error("Bitwise operation not allowed between incompatible bitmasks '$(typeof(a))', '$(typeof(b))'")
+isless(a::BitMask, b::BitMask) = error("Bitwise operation not allowed between incompatible bitmasks '$(typeof(a))', '$(typeof(b))'")
 
 (&)(a::T, b::T) where {T <: BitMask} = T(a.val & b.val)
 (|)(a::T, b::T) where {T <: BitMask} = T(a.val | b.val)
 xor(a::T, b::T) where {T <: BitMask} = T(xor(a.val, b.val))
+isless(a::T, b::T) where {T <: BitMask} = T(isless(a.val, b.val))
 
 (&)(a::T, b::Integer) where {T <: BitMask} = T(a.val & b)
 (|)(a::T, b::Integer) where {T <: BitMask} = T(a.val | b)
 xor(a::T, b::Integer) where {T <: BitMask} = T(xor(a.val, b))
+isless(a::T, b::Integer) where {T <: BitMask} = T(isless(a.val, b))
 
 (&)(a::Integer, b::T) where {T <: BitMask} = b & a
 (|)(a::Integer, b::T) where {T <: BitMask} = b | a
 xor(a::Integer, b::T) where {T <: BitMask} = xor(b, a)
+isless(a::Integer, b::T) where {T <: BitMask} = isless(b, a)
 
 (::Type{T})(bm::BitMask) where {T <: Integer} = T(bm.val)
 

--- a/src/prewrap/bitmasks.jl
+++ b/src/prewrap/bitmasks.jl
@@ -31,17 +31,17 @@ isless(a::BitMask, b::BitMask) = error("Bitwise operation not allowed between in
 (&)(a::T, b::T) where {T <: BitMask} = T(a.val & b.val)
 (|)(a::T, b::T) where {T <: BitMask} = T(a.val | b.val)
 xor(a::T, b::T) where {T <: BitMask} = T(xor(a.val, b.val))
-isless(a::T, b::T) where {T <: BitMask} = T(isless(a.val, b.val))
+isless(a::T, b::T) where {T <: BitMask} = isless(a.val, b.val)
 
 (&)(a::T, b::Integer) where {T <: BitMask} = T(a.val & b)
 (|)(a::T, b::Integer) where {T <: BitMask} = T(a.val | b)
 xor(a::T, b::Integer) where {T <: BitMask} = T(xor(a.val, b))
-isless(a::T, b::Integer) where {T <: BitMask} = T(isless(a.val, b))
+isless(a::T, b::Integer) where {T <: BitMask} = isless(a.val, b)
 
 (&)(a::Integer, b::T) where {T <: BitMask} = b & a
 (|)(a::Integer, b::T) where {T <: BitMask} = b | a
 xor(a::Integer, b::T) where {T <: BitMask} = xor(b, a)
-isless(a::Integer, b::T) where {T <: BitMask} = isless(b, a)
+isless(a::Integer, b::T) where {T <: BitMask} = isless(a, b.val) # need b.val to prevent stackoverflow
 
 (::Type{T})(bm::BitMask) where {T <: Integer} = T(bm.val)
 

--- a/src/prewrap/bitmasks.jl
+++ b/src/prewrap/bitmasks.jl
@@ -38,10 +38,10 @@ isless(a::T, b::T) where {T <: BitMask} = T(isless(a.val, b.val))
 xor(a::T, b::Integer) where {T <: BitMask} = T(xor(a.val, b))
 isless(a::T, b::Integer) where {T <: BitMask} = T(isless(a.val, b))
 
-(&)(a::Integer, b::T) where {T <: BitMask} = b.val & a
-(|)(a::Integer, b::T) where {T <: BitMask} = b.val | a
-xor(a::Integer, b::T) where {T <: BitMask} = xor(b.val, a)
-isless(a::Integer, b::T) where {T <: BitMask} = isless(b.val, a)
+(&)(a::Integer, b::T) where {T <: BitMask} = b & a
+(|)(a::Integer, b::T) where {T <: BitMask} = b | a
+xor(a::Integer, b::T) where {T <: BitMask} = xor(b, a)
+isless(a::Integer, b::T) where {T <: BitMask} = isless(b, a)
 
 (::Type{T})(bm::BitMask) where {T <: Integer} = T(bm.val)
 

--- a/test/bitmasks.jl
+++ b/test/bitmasks.jl
@@ -20,7 +20,5 @@ end
     @test xor(BIT_A, 2) == xor(2, BIT_A) == BIT_C
     @test 1 < BIT_B && BIT_B < 3
     @test BIT_A <= BIT_B <= BIT_C
-    @test BIT_A <= 1
-    @test 1 <= BIT_A
     @test_throws ErrorException("Bitwise operation not allowed between incompatible bitmasks 'FlagBits', 'FlagBits2'") BIT_A & BIT_A_2
 end

--- a/test/bitmasks.jl
+++ b/test/bitmasks.jl
@@ -14,10 +14,13 @@ end
     @test BIT_A & BIT_B == FlagBits(0)
     @test BIT_A | BIT_B == BIT_C
     @test xor(BIT_A, BIT_B) == BIT_C
-    @test isless(BIT_A, BIT_B) && isless(BIT_B, BIT_C) && isless(BIT_A, BIT_C)
+    @test BIT_A < BIT_B && BIT_B < BIT_C && BIT_A < BIT_C
     @test BIT_A & 1 == 1 & BIT_A == BIT_A
     @test BIT_A | 2 == 2 | BIT_A == BIT_C
     @test xor(BIT_A, 2) == xor(2, BIT_A) == BIT_C
-    @test isless(1, BIT_B) && isless(BIT_B, 3)
+    @test 1 < BIT_B && BIT_B < 3
+    @test BIT_A <= BIT_B <= BIT_C
+    @test BIT_A <= 1
+    @test 1 <= BIT_A
     @test_throws ErrorException("Bitwise operation not allowed between incompatible bitmasks 'FlagBits', 'FlagBits2'") BIT_A & BIT_A_2
 end

--- a/test/bitmasks.jl
+++ b/test/bitmasks.jl
@@ -14,8 +14,10 @@ end
     @test BIT_A & BIT_B == FlagBits(0)
     @test BIT_A | BIT_B == BIT_C
     @test xor(BIT_A, BIT_B) == BIT_C
+    @test isless(BIT_A, BIT_B) && isless(BIT_B, BIT_C) && isless(BIT_A, BIT_C)
     @test BIT_A & 1 == 1 & BIT_A == BIT_A
     @test BIT_A | 2 == 2 | BIT_A == BIT_C
     @test xor(BIT_A, 2) == xor(2, BIT_A) == BIT_C
+    @test isless(1, BIT_B) && isless(BIT_B, 3)
     @test_throws ErrorException("Bitwise operation not allowed between incompatible bitmasks 'FlagBits', 'FlagBits2'") BIT_A & BIT_A_2
 end


### PR DESCRIPTION
Fixes #10.

I've also added `.val` to three of the definitions that missed them.