### PR TITLE
[docs] Add the venerable&useful "minimal compute example"

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -5,6 +5,8 @@ Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 SwiftShader_jll = "c404ff5a-e271-5628-8eaa-423d39d64c15"
 Vulkan_Headers_jll = "8d446b21-f3ad-5576-a034-752265b9b6f9"
+glslang_jll = "6fd5517d-459c-5c5a-9b1a-c968b4e37a81"
 
 [compat]
 Vulkan_Headers_jll = "1.2.177"
+glslang_jll = "11"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -45,6 +45,7 @@ makedocs(;
             "Resource management" => "tutorial/resource_management.md",
             "Dispatch" => "tutorial/dispatch.md",
             "In-depth tutorial" => "tutorial/indepth.md",
+            "Running compute shaders" => "tutorial/minimal_working_compute.md",
         ],
         "How to" => [
             "howto/preferences.md",

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -157,8 +157,8 @@ shader = unwrap(create_shader_module(device, sizeof(UInt32) * length(shader_bcod
 
 # ## Assembling the pipeline
 #
-# Descriptor set layout describes how many buffers of what kind are going to be
-# used by the shader:
+# Descriptor set layout describes how many resources of what kind are going to
+# be used by the shader. In this case, we only use a single buffer:
 dsl = unwrap(
     create_descriptor_set_layout(
         device,

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -1,0 +1,269 @@
+
+#=
+
+# Minimal working compute example
+
+The amount of control offered by Vulkan is not a very welcome property for
+users who just want to run a simple shader to compute something quickly, and
+the effort required for the "first good run" is often quite deterrent. To ease
+the struggle, this tutorial gives precisely the small "bootstrap" piece of code
+that should allow you to quickly run a compute shader on actual data. In short,
+we walk through the following steps:
+
+- Opening a device and finding good queues families and memory types
+- Allocating memory and buffers
+- Compiling a shader program and filling up the structures necessary to run it:
+  - specialization constants
+  - push constants
+  - descriptor sets and layouts
+- Making a command buffer and submitting it to the queue, efficiently running
+  the shader
+
+## Initialization
+
+=#
+
+using SwiftShader_jll # hide
+using Vulkan
+@set_driver :SwiftShader # hide
+
+instance = Instance([], [])
+
+# Take the first available physical device (you might check that it is an
+# actual GPU, using [`get_physical_device_properties`](@ref)).
+physical_device = first(unwrap(enumerate_physical_devices(instance)))
+
+# At this point, we need to choose a queue family index to use. For this
+# example, have a look at `vulkaninfo` command and pick the good queue manually
+# from the list of `VkQueueFamilyProperties` -- you want one that has
+# `QUEUE_COMPUTE` in the flags. In a production environment, you would use
+# [`get_physical_device_queue_family_properties`](@ref) to find a good index.
+qfam_idx = 0
+
+# Create a device object and make a queue for our purposes.
+device = Device(physical_device, [DeviceQueueCreateInfo(qfam_idx, [1.0])], [], [])
+
+# ## Allocating the memory
+#
+# Same way, you need to find a good memory type. Again, you can find a good one
+# using `vulkaninfo` or with [`get_physical_device_memory_properties`](@ref).
+# For compute, you want something that is both at the device (contains
+# `MEMORY_PROPERTY_DEVICE_LOCAL_BIT`) and visible from the host
+# (`..._HOST_VISIBLE_BIT`).
+memorytype_idx = 0
+
+# Let's create some data. We will work with 100 flimsy floats.
+data_items = 100
+mem_size = sizeof(Float32) * data_items
+
+# Allocate the memory of the correct type
+mem = unwrap(allocate_memory(device, mem_size, memorytype_idx))
+
+# Make a buffer that will be used to access the memory, and bind it to the
+# memory. (Memory allocations may be quite demanding, it is therefore often
+# better to allocate a single big chunk of memory, and create multiple buffers
+# that view it as smaller arrays.)
+buffer = unwrap(
+    create_buffer(
+        device,
+        mem_size,
+        BUFFER_USAGE_STORAGE_BUFFER_BIT,
+        SHARING_MODE_EXCLUSIVE,
+        [qfam_idx],
+    ),
+)
+
+bind_buffer_memory(device, buffer, mem, 0)
+
+# ## Uploading the data to the device
+#
+# First, map the memory and get a pointer to it.
+memptr = map_memory(device, mem, 0, mem_size)
+
+# Here we force Julia to look at the mapped data as at the vector of
+# `Float32`s, so that we can access it easily.
+data = unsafe_wrap(Vector{Float32}, convert(Ptr{Float32}, unwrap(memptr)), data_items, own = false)
+
+# For now, let's just zero out all the data, and *flush* the changes to make
+# sure the device can see the updated data. This is the simplest way to move
+# array data to the device.
+data .= 0
+flush_mapped_memory_ranges(device, [MappedMemoryRange(mem, 0, mem_size)])
+
+# Eventually, you may need to allocate memory types that are not visible from
+# host, because these provide better capacity and speed on the discrete GPUs.
+# At that point, you may need to use the transfer queue and memory transfer
+# commands to get the data from host-visible to GPU-local memory, using e.g.
+# [`cmd_copy_buffer`](@ref).
+
+# ## Compiling the shader
+#
+# Now we need to make a shader program. We will use `glslangValidator` packaged
+# in a JLL to compile a GLSL program from a string into a spir-v bytecode,
+# which is later passed to the GPU drivers.
+
+shader_code = """
+#version 430
+
+layout (local_size_x_id = 0) in;
+layout (local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+
+layout(constant_id = 0) const uint blocksize = 1; // copy of local_size_x
+
+layout (push_constant) uniform Params
+{
+    float val;
+    uint n;
+} params;
+
+layout(std430, binding=0) buffer databuf
+{
+    float data[];
+};
+
+void
+main()
+{
+    uint i = gl_GlobalInvocationID.x;
+    if(i < params.n) data[i] = params.val * i;
+}
+"""
+
+# Push constants are small packs of variables that are used to quickly send
+# configuration data to the shader runs. Make sure that this structure
+# corresponds to what is declared in the shader.
+struct shader_push_consts
+    val::Float32
+    n::UInt32
+end
+
+# Specialization constants are similar to push constants, but less dynamic: You
+# can change them before compiling the shader for the pipeline, but not
+# dynamically. This may have performance benefits for "very static" values,
+# such as block sizes.
+struct shader_spec_consts
+    local_size_x::UInt32
+end
+
+# Run the `glslangValidator` program to compile the shader.
+using glslang_jll
+glslang = glslangValidator(
+    bin -> open(
+        `$bin -V --quiet --stdin -S comp -o /dev/stdout `,
+        read = true,
+        write = true,
+    ),
+)
+write(glslang, shader_code) # send the code to stdin
+close(glslang.in) # send EOF
+shader_bcode = collect(reinterpret(UInt32, read(glslang))) #read the compiled shader spir-v code
+close(glslang)
+@assert glslang.exitcode == 0
+
+# Make a shader module with the code
+shader = unwrap(create_shader_module(device, sizeof(UInt32)*length(shader_bcode), shader_bcode))
+
+# ## Assembling the pipeline
+#
+# Descriptor set layout describes how many buffers of what kind are going to be
+# used by the shader
+dsl = unwrap(
+    create_descriptor_set_layout(
+        device,
+        [
+            DescriptorSetLayoutBinding(
+                0,
+                DESCRIPTOR_TYPE_STORAGE_BUFFER,
+                1,
+                SHADER_STAGE_COMPUTE_BIT,
+                Sampler[],
+            ),
+        ],
+    ),
+)
+
+# Pipeline layout describes the descriptor set together with the location of
+# push constants
+pl = unwrap(
+    create_pipeline_layout(
+        device,
+        [dsl],
+        [PushConstantRange(SHADER_STAGE_COMPUTE_BIT, 0, sizeof(shader_push_consts))],
+    ),
+)
+
+# Shader compilation can use "specialization constants" that get propagated
+# (and optimized) into the shader code. We use them to make the shader
+# workgroup size "dynamic" in the sense that the size (32) is not hardcoded in
+# GLSL, but instead taken from here.
+const_local_size_x = 32
+spec_consts = [shader_spec_consts(const_local_size_x)]
+
+# Create a pipeline that can run the shader code with the specified layout.
+p = first(first(unwrap(
+    create_compute_pipelines(
+        device,
+        [
+            ComputePipelineCreateInfo(
+                PipelineShaderStageCreateInfo(
+                    SHADER_STAGE_COMPUTE_BIT,
+                    shader,
+                    "main", # this needs to match the function name in the shader
+                    specialization_info = SpecializationInfo(
+                        [SpecializationMapEntry(0, 0, 4)],
+                        UInt64(4),
+                        Ptr{Nothing}(pointer(spec_consts)),
+                    ),
+                ),
+                pl,
+                -1,
+            ),
+        ],
+    ),
+)))
+
+# Now make a descriptor pool that is used to allocate the buffer descriptors
+# from (not a big one, just 1 descriptor set and total 1 descriptor)
+dpool = unwrap(create_descriptor_pool(device, 1, [DescriptorPoolSize(DESCRIPTOR_TYPE_STORAGE_BUFFER, 1)]))
+
+# Allocate the descriptors for our layout
+dsets = unwrap(allocate_descriptor_sets(device, DescriptorSetAllocateInfo(dpool, [dsl])))
+dset = first(dsets)
+
+# Make the descriptors point to the right buffers
+update_descriptor_sets(device, [WriteDescriptorSet(dset, 0, 0, DESCRIPTOR_TYPE_STORAGE_BUFFER, [], [DescriptorBufferInfo(buffer, 0, WHOLE_SIZE)], [])], [])
+
+# ## Executing the shader
+#
+# Let's create a command pool in the right queue family, and take a command
+# buffer out of that.
+cmdpool = unwrap(create_command_pool(device, qfam_idx))
+cbufs = unwrap(allocate_command_buffers(device, CommandBufferAllocateInfo(cmdpool, COMMAND_BUFFER_LEVEL_PRIMARY, 1)))
+cbuf = first(cbufs)
+
+# Now that we have a command buffer, we can fill it with commands that cause
+# the kernel to be run. Basically, we bind and fill everything, and then
+# dispatch a sufficient amount of invocations of the shader to span over the
+# array.
+begin_command_buffer(cbuf, CommandBufferBeginInfo(flags=COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT))
+cmd_bind_pipeline(cbuf, PIPELINE_BIND_POINT_COMPUTE, p)
+const_buf = [shader_push_consts(1.234, data_items)]
+cmd_push_constants(cbuf, pl, SHADER_STAGE_COMPUTE_BIT, 0, sizeof(shader_push_consts), Ptr{Nothing}(pointer(const_buf)))
+cmd_bind_descriptor_sets(cbuf, PIPELINE_BIND_POINT_COMPUTE, pl, 0, [dset], [])
+cmd_dispatch(cbuf, div(data_items, const_local_size_x, RoundUp), 1, 1)
+end_command_buffer(cbuf)
+
+# Finanly, find a handle to the compute queue and send the command to execute the shader!
+compute_q = get_device_queue(device, qfam_idx, 0)
+queue_submit(compute_q, [SubmitInfo([], [], [cbuf], [])])
+
+# ## Getting the data
+#
+# Now, data is being crunched in the background. To get the data, we need to
+# wait for completion and invalidate the mapped memory (so that whatever
+# happened on the GPU gets to the mapped range visible for the "host" device.
+queue_wait_idle(compute_q)
+invalidate_mapped_memory_ranges(device, [MappedMemoryRange(mem, 0, mem_size)])
+
+# Finally, look at the data filled by your compute shader!
+display(data) # WHOA

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -180,31 +180,22 @@ const_local_size_x = 32
 spec_consts = [ShaderSpecConsts(const_local_size_x)]
 
 # Next, we create a pipeline that can run the shader code with the specified layout:
-p = first(
-    first(
-        unwrap(
-            create_compute_pipelines(
-                device,
-                [
-                    ComputePipelineCreateInfo(
-                        PipelineShaderStageCreateInfo(
-                            SHADER_STAGE_COMPUTE_BIT,
-                            shader,
-                            "main", # this needs to match the function name in the shader
-                            specialization_info = SpecializationInfo(
-                                [SpecializationMapEntry(0, 0, 4)],
-                                UInt64(4),
-                                Ptr{Nothing}(pointer(spec_consts)),
-                            ),
-                        ),
-                        pl,
-                        -1,
-                    ),
-                ],
-            ),
+pipeline_info = ComputePipelineCreateInfo(
+    PipelineShaderStageCreateInfo(
+        SHADER_STAGE_COMPUTE_BIT,
+        shader,
+        "main", # this needs to match the function name in the shader
+        specialization_info = SpecializationInfo(
+            [SpecializationMapEntry(0, 0, 4)],
+            UInt64(4),
+            Ptr{Nothing}(pointer(spec_consts)),
         ),
     ),
+    pl,
+    -1,
 )
+ps, _ = unwrap(create_compute_pipelines(device, [pipeline_info]))
+p = first(ps)
 
 # Now make a descriptor pool to allocate the buffer descriptors from (not a big
 # one, just 1 descriptor set with 1 descriptor in total), ...

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -267,17 +267,23 @@ queue_submit(compute_q, [SubmitInfo([], [], [cbuf], [])])
 # get the resulting data, we need to wait for completion and invalidate the
 # mapped memory (so that whatever data updates that happened on the GPU get
 # transferred to the mapped range visible for the host).
-# Wait for computations to be carried out, while making sure data is kept alive
-# during queue operations. In non-global scopes, such as functions, the compiler
-# may skip the allocation of unused variables or garbage-collect variables that the
-# runtime thinks are unused. Notably, the runtime is not aware that there is a memory
-# dependency with these variables until that command returns, so we tell it manually.
+#
+# While [`queue_wait_idle`](@ref) will wait for computations to be carried out,
+# we need to make sure that the required data is kept alive during queue
+# operations. In non-global scopes, such as functions, the compiler may skip
+# the allocation of unused variables or garbage-collect variables that the
+# runtime thinks are no longer used, thus possibly breaking the initialization
+# logic of Vulkan objects. In this particular case, the runtime is not aware
+# that for example the pipeline and buffer objects are still used and that
+# there's a dependency with these variables until the command returns, so we
+# tell it manually.
 GC.@preserve buff dsl pl p dpool dset cmdpool cbuf const_buf begin
     queue_wait_idle(compute_q)
 end
 
-# Note that the invalidation is only required for memory that is not host-coherent,
-# so you may not need this step if your memory has the right property flag.
+# Just as with flushing, the invalidation is only required for memory that is
+# not host-coherent. You may skip this step if you check that the memory has
+# the host-coherent property flag.
 invalidate_mapped_memory_ranges(device, [MappedMemoryRange(mem, 0, mem_size)])
 
 # Finally, let's have a look at the data created by your compute shader!

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -145,7 +145,9 @@ shader_bcode = mktempdir() do dir
     inpath = joinpath(dir, "shader.comp")
     outpath = joinpath(dir, "shader.spv")
     open(f -> write(f, shader_code), inpath, "w")
-    status = glslangValidator(bin -> run(`$bin -V -S comp -o $outpath $inpath`))
+    status = glslangValidator() do glslang
+        run(`$glslang -V -S comp -o $outpath $inpath`)
+    end
     @assert status.exitcode == 0
     reinterpret(UInt32, read(outpath))
 end

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -141,14 +141,14 @@ end
 
 # `glslangValidator` program is used to compile the shader:
 using glslang_jll
-shader_bcode = mktempdir(dir -> begin
+shader_bcode = mktempdir() do dir
     inpath = joinpath(dir, "shader.comp")
     outpath = joinpath(dir, "shader.spv")
     open(f -> write(f, shader_code), inpath, "w")
     status = glslangValidator(bin -> run(`$bin -V -S comp -o $outpath $inpath`))
     @assert status.exitcode == 0
-    reinterpret(UInt32, open(f -> read(f), outpath, "r"))
-end)
+    reinterpret(UInt32, read(outpath))
+end
 
 # We can now make a shader module with the compiled code:
 shader = unwrap(create_shader_module(device, sizeof(UInt32) * length(shader_bcode), shader_bcode))

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -271,9 +271,10 @@ queue_submit(compute_q, [SubmitInfo([], [], [cbuf], [])])
 # While [`queue_wait_idle`](@ref) will wait for computations to be carried out,
 # we need to make sure that the required data is kept alive during queue
 # operations. In non-global scopes, such as functions, the compiler may skip
-# the allocation of unused variables or garbage-collect variables that the
-# runtime thinks are no longer used, thus possibly breaking the initialization
-# logic of Vulkan objects. In this particular case, the runtime is not aware
+# the allocation of unused variables or garbage-collect objects that the
+# runtime thinks are no longer used. If garbage-collected, objects will call
+# their finalizers which imply the destruction of the Vulkan objects
+# (via `vkDestroy...`). In this particular case, the runtime is not aware
 # that for example the pipeline and buffer objects are still used and that
 # there's a dependency with these variables until the command returns, so we
 # tell it manually.

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -162,7 +162,7 @@ shader = unwrap(create_shader_module(device, sizeof(UInt32) * length(shader_bcod
 dsl = unwrap(
     create_descriptor_set_layout(
         device,
-        [DescriptorSetLayoutBinding(0, DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, SHADER_STAGE_COMPUTE_BIT, Sampler[])],
+        [DescriptorSetLayoutBinding(0, DESCRIPTOR_TYPE_STORAGE_BUFFER, SHADER_STAGE_COMPUTE_BIT; descriptor_count = 1)],
     ),
 )
 

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -74,7 +74,7 @@ memptr = unwrap(map_memory(device, mem, 0, mem_size))
 
 # Here we make Julia to look at the mapped data as a vector of `Float32`s, so
 # that we can access it easily:
-data = unsafe_wrap(Vector{Float32}, convert(Ptr{Float32}, memptr), data_items, own = false)
+data = unsafe_wrap(Vector{Float32}, convert(Ptr{Float32}, memptr), data_items, own = false);
 
 # For now, let's just zero out all the data, and *flush* the changes to make
 # sure the device can see the updated data. This is the simplest way to move

--- a/docs/src/tutorial/minimal_working_compute.jl
+++ b/docs/src/tutorial/minimal_working_compute.jl
@@ -126,7 +126,7 @@ main()
 # Push constants are small packs of variables that are used to quickly send
 # configuration data to the shader runs. Make sure that this structure
 # corresponds to what is declared in the shader.
-struct shader_push_consts
+struct ShaderPushConsts
     val::Float32
     n::UInt32
 end
@@ -135,7 +135,7 @@ end
 # can change them before compiling the shader for the pipeline, but not
 # dynamically. This may have performance benefits for "very static" values,
 # such as block sizes.
-struct shader_spec_consts
+struct ShaderSpecConsts
     local_size_x::UInt32
 end
 
@@ -169,7 +169,7 @@ dsl = unwrap(
 # Pipeline layout describes the descriptor set together with the location of
 # push constants:
 pl = unwrap(
-    create_pipeline_layout(device, [dsl], [PushConstantRange(SHADER_STAGE_COMPUTE_BIT, 0, sizeof(shader_push_consts))]),
+    create_pipeline_layout(device, [dsl], [PushConstantRange(SHADER_STAGE_COMPUTE_BIT, 0, sizeof(ShaderPushConsts))]),
 )
 
 # Shader compilation can use "specialization constants" that get propagated
@@ -177,7 +177,7 @@ pl = unwrap(
 # workgroup size "dynamic" in the sense that the size (32) is not hardcoded in
 # GLSL, but instead taken from here.
 const_local_size_x = 32
-spec_consts = [shader_spec_consts(const_local_size_x)]
+spec_consts = [ShaderSpecConsts(const_local_size_x)]
 
 # Next, we create a pipeline that can run the shader code with the specified layout:
 p = first(
@@ -247,8 +247,8 @@ begin_command_buffer(cbuf, CommandBufferBeginInfo(flags = COMMAND_BUFFER_USAGE_O
 
 cmd_bind_pipeline(cbuf, PIPELINE_BIND_POINT_COMPUTE, p)
 
-const_buf = [shader_push_consts(1.234, data_items)]
-cmd_push_constants(cbuf, pl, SHADER_STAGE_COMPUTE_BIT, 0, sizeof(shader_push_consts), Ptr{Nothing}(pointer(const_buf)))
+const_buf = [ShaderPushConsts(1.234, data_items)]
+cmd_push_constants(cbuf, pl, SHADER_STAGE_COMPUTE_BIT, 0, sizeof(ShaderPushConsts), Ptr{Nothing}(pointer(const_buf)))
 
 cmd_bind_descriptor_sets(cbuf, PIPELINE_BIND_POINT_COMPUTE, pl, 0, [dset], [])
 


### PR DESCRIPTION
Also shows how to use glslang to compile shaders, closing #33 . Comments and code styling hints very welcome.

I'm not sure how much the use of `glslangValidator` is actually portable between platforms; I wanted to avoid temporary files. Let me know if there's a better way to do that.
