### PR TITLE
added high level Device method to bypass deprecation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Vulkan"
 uuid = "9f14b124-c50e-4008-a7d4-969b3a6cd68a"
 authors = ["Cédric Belmant"]
-version = "0.6.29"
+version = "0.6.30"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/device.jl
+++ b/src/device.jl
@@ -89,3 +89,37 @@ end
 device_or_nothing(device::Device) = device
 device_or_nothing(handle::Handle) = device_or_nothing(parent(handle))
 device_or_nothing(::Nothing) = nothing
+
+
+#====================================================================================================
+NOTE: the below is special handling of Device for the sake of removing a deprecation warning which
+    otherwise is always triggered by the wrapper constructors.
+
+    The Device method provided here is more specific and thus usually takes precedence,
+    users should use this method.
+====================================================================================================#
+function _device_create_info(queue_create_infos::AbstractArray, enabled_extension_names::AbstractArray;
+    next = C_NULL, flags = 0, enabled_features = C_NULL,
+)
+    queue_create_info_count = pointer_length(queue_create_infos)
+    enabled_layer_count = 0
+    enabled_extension_count = pointer_length(enabled_extension_names)
+    next = cconvert(Ptr{Cvoid}, next)
+    queue_create_infos = cconvert(Ptr{VkDeviceQueueCreateInfo}, queue_create_infos)
+    enabled_layer_names = C_NULL
+    enabled_extension_names = cconvert(Ptr{Cstring}, enabled_extension_names)
+    enabled_features = cconvert(Ptr{VkPhysicalDeviceFeatures}, enabled_features)
+    deps = Any[next, queue_create_infos, enabled_layer_names, enabled_extension_names, enabled_features]
+    vks = VkDeviceCreateInfo(structure_type(VkDeviceCreateInfo), unsafe_convert(Ptr{Cvoid}, next), flags, queue_create_info_count, unsafe_convert(Ptr{VkDeviceQueueCreateInfo}, queue_create_infos), enabled_layer_count, unsafe_convert(Ptr{Cstring}, enabled_layer_names), enabled_extension_count, unsafe_convert(Ptr{Cstring}, enabled_extension_names), unsafe_convert(Ptr{VkPhysicalDeviceFeatures}, enabled_features))
+    _DeviceCreateInfo(vks, deps)
+end
+
+function Device(physical_device::PhysicalDevice,
+    queue_create_infos::AbstractArray,
+    enabled_layers::AbstractArray, enabled_extension_names::AbstractArray;
+    next=C_NULL, flags=0, enabled_features=C_NULL,
+)
+    isempty(enabled_layers) || @warn("Device: enabled_layers is long deprecated, will be ignored")
+    info = _device_create_info(queue_create_infos, enabled_extension_names; next, flags, enabled_features)
+    unwrap(_create_device(physical_device, info))
+end


### PR DESCRIPTION
This adds a high level `Device` method which specializes on the first `PhysicalDevice` argument and thus usually takes precedence.

The reason for adding this is to get around a particularly annoying deprecation which is almost completely unavoidable without the addition of a new method.  Device layers are long since deprecated (since 1.0), however Vulkan takes API breakage extremely seriously, so the arguments of `VkDeviceCreateInfo` and `VkDevice` have not changed.  This means that there are two arguments to these functions which are required to be `0`, one a length and one a null pointer.  The Vulkan.jl wrapper will always provide as one of these arguments the pointer to a length-0 array in the heap which cannot have a null pointer.  Therefore Vulkan sees the non-null pointer and throws a deprecation warning (assuming appropriate instance layers are enabled).

I think it is worth adding this because this deprecation warning is otherwise extremely hard to elide, and it even shows up during precompilation (as a somewhat alarming "error") without this patch.  Arguably there is a better fix to be had in which we have our own version of `cconvert` which checks for empty arrays and gives a null pointer in those cases, since the vulkan API docs hint that null pointers should always be passed for empty arrays, but this seemed rather heavy handed, and the patch I've included here is minimally invasive and fixes the vast majority of occurrences of this infuriating warning.